### PR TITLE
CI: remove unused ECR_NGINX requirement

### DIFF
--- a/scripts/deploy-ecs-tasks.sh
+++ b/scripts/deploy-ecs-tasks.sh
@@ -18,7 +18,6 @@ check_env_vars() {
         "ECR_REGISTRY"
         "ECR_API_SERVICE"
         "ECR_ML_SERVICE"
-        "ECR_NGINX"
         "DB_HOST"
         "DB_PASSWORD"
         "SECRET_KEY"


### PR DESCRIPTION
배포 스크립트에서 Nginx 제거 이후에도 남아있던 ECR_NGINX 필수 체크 제거. main 배포 실패 원인 해결.