### PR TITLE
Switch ML model to krbert_morph_s2d_fin_0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     ports:
       - "8001:8001"
     environment:
-      - MODEL_NAME=unu-dev/krbert_ms2d_v1
+      - MODEL_NAME=unu-dev/krbert_morph_s2d_fin_0.1
       - DEVICE=cuda  
       - API_SERVICE_URL=http://api:8000
       - PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:512

--- a/ecs-task-definitions/ml-service-gpu.json
+++ b/ecs-task-definitions/ml-service-gpu.json
@@ -34,7 +34,7 @@
       "environment": [
         {
           "name": "MODEL_NAME",
-          "value": "unu-dev/krbert_ms2d_v1"
+          "value": "unu-dev/krbert_morph_s2d_fin_0.1"
         },
         {
           "name": "DEVICE",

--- a/ml-service/Dockerfile
+++ b/ml-service/Dockerfile
@@ -34,7 +34,7 @@ RUN mkdir -p /app/konlpy_data
 ENV KONLPY_DATA_PATH=/app/konlpy_data
 
 # 환경 변수 설정
-ENV MODEL_NAME=unu-dev/krbert_ms2d_v1
+ENV MODEL_NAME=unu-dev/krbert_morph_s2d_fin_0.1
 ENV DEVICE=cuda
 ENV API_SERVICE_URL=http://api-service:8000
 

--- a/ml-service/main.py
+++ b/ml-service/main.py
@@ -30,7 +30,7 @@ ml_api = FastAPI(
 )
 
 # 환경 변수
-MODEL_NAME = os.getenv("MODEL_NAME", "unu-dev/krbert_ms2d_v1")
+MODEL_NAME = os.getenv("MODEL_NAME", "unu-dev/krbert_morph_s2d_fin_0.1")
 DEVICE = (
     "cuda"
     if torch.cuda.is_available() and os.getenv("DEVICE", "cpu") == "cuda"


### PR DESCRIPTION
- Update MODEL_NAME across ML service (code, Dockerfile, compose, ECS task def)
- No logic changes; only model ID switch to unu-dev/krbert_morph_s2d_fin_0.1

Verify:
- Health: /ml/health shows model_name updated
- ECS: register new task definition and update service if CI doesn’t auto-deploy.