### PR TITLE
Chat: windowed context + DB persistence improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,11 +97,11 @@ test_websocket.html
 
 # Alembic
 alembic/__pycache__/
-alembic/versions/*.py
+# 버전 파일은 커밋 대상으로 유지
+!alembic/versions/*.py
 
 # 배포 스크립트는 포함하되 실행 결과 제외
 scripts/logs/
 scripts/tmp/
 scripts/migrate-simple.sh
 scripts/migrate.sh
-

--- a/alembic/versions/005_add_last_recommendation_pivot_to_chat_rooms.py
+++ b/alembic/versions/005_add_last_recommendation_pivot_to_chat_rooms.py
@@ -1,0 +1,29 @@
+"""
+Add last_recommendation_message_id to chat_rooms for windowed context
+
+Revision ID: 005_add_chatroom_pivot
+Revises: 004_create_disease_equipment_categories
+Create Date: 2025-09-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '005_add_chatroom_pivot'
+down_revision = '004_create_disease_equipment_categories'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'chat_rooms',
+        sa.Column('last_recommendation_message_id', sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('chat_rooms', 'last_recommendation_message_id')
+

--- a/app/models/chat.py
+++ b/app/models/chat.py
@@ -44,6 +44,8 @@ class ChatRoom(Base):
     user = relationship("User", back_populates="chat_rooms")
     messages = relationship("ChatMessage", back_populates="chat_room")
     final_disease = relationship("Disease", back_populates="chat_rooms")
+    # 추천 컨텍스트 경계: 직전 추천을 유발한 USER 메시지 ID
+    last_recommendation_message_id = Column(Integer, nullable=True)
 
 
 class ChatMessage(Base):

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -129,3 +129,13 @@ class ChatService:
         db.commit()
 
         return True
+
+    @staticmethod
+    def update_last_recommendation_pivot(db: Session, room_id: int, message_id: int) -> bool:
+        """추천 발생 시점의 USER 메시지 ID를 피벗으로 저장하여 윈도우를 리셋한다."""
+        chat_room = ChatService.get_chat_room(db, room_id)
+        if not chat_room:
+            return False
+        setattr(chat_room, "last_recommendation_message_id", int(message_id))
+        db.commit()
+        return True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     ports:
       - "8001:8001"
     environment:
-      - MODEL_NAME=unu-dev/krbert_ms2d_v1
+      - MODEL_NAME=unu-dev/krbert_morph_s2d_fin_0.1
       - DEVICE=cuda  
       - API_SERVICE_URL=http://api:8000
       - PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:512

--- a/ecs-task-definitions/ml-service-gpu.json
+++ b/ecs-task-definitions/ml-service-gpu.json
@@ -34,7 +34,7 @@
       "environment": [
         {
           "name": "MODEL_NAME",
-          "value": "unu-dev/krbert_ms2d_v1"
+          "value": "unu-dev/krbert_morph_s2d_fin_0.1"
         },
         {
           "name": "DEVICE",

--- a/ml-service/Dockerfile
+++ b/ml-service/Dockerfile
@@ -34,7 +34,7 @@ RUN mkdir -p /app/konlpy_data
 ENV KONLPY_DATA_PATH=/app/konlpy_data
 
 # 환경 변수 설정
-ENV MODEL_NAME=unu-dev/krbert_ms2d_v1
+ENV MODEL_NAME=unu-dev/krbert_morph_s2d_fin_0.1
 ENV DEVICE=cuda
 ENV API_SERVICE_URL=http://api-service:8000
 

--- a/ml-service/main.py
+++ b/ml-service/main.py
@@ -30,7 +30,7 @@ ml_api = FastAPI(
 )
 
 # 환경 변수
-MODEL_NAME = os.getenv("MODEL_NAME", "unu-dev/krbert_ms2d_v1")
+MODEL_NAME = os.getenv("MODEL_NAME", "unu-dev/krbert_morph_s2d_fin_0.1")
 DEVICE = (
     "cuda"
     if torch.cuda.is_available() and os.getenv("DEVICE", "cpu") == "cuda"


### PR DESCRIPTION
- Add windowed context policy using ChatRoom.last_recommendation_message_id pivot
- Combine only USER messages after pivot when building model input
- Persist 2nd/3rd predictions into ModelInferenceResult
- On threshold met, persist HospitalRecommendation and update pivot to start a new window
- Add Alembic migration (005) and allow versions to be tracked in .gitignore

Notes:
- Combined text saved to ModelInferenceResult.input_text
- BOT messages are excluded from context
- SYMPTOM_HISTORY_UTTERANCES controls N window size.