### PR TITLE
CI: run Alembic migrations after deploy; track Alembic versions

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -177,6 +177,31 @@ jobs:
 
         # Nginx 서비스 제거됨 - ALB에서 직접 라우팅
 
+    # Alembic 마이그레이션 (API 컨테이너 내에서 실행)
+    - name: Run Alembic migrations on API service
+      if: steps.env.outputs.environment == 'prod'
+      env:
+        CLUSTER: medic-gpu-cluster
+      run: |
+        set -e
+        echo "Enabling execute-command on API service (idempotent)"
+        aws ecs update-service --cluster $CLUSTER \
+                               --service medic-api-service \
+                               --enable-execute-command \
+                               --region ${{ env.AWS_REGION }} >/dev/null || true
+        echo "Fetching latest API task ARN"
+        TASK_ARN=$(aws ecs list-tasks --cluster $CLUSTER \
+                                         --service-name medic-api-service \
+                                         --region ${{ env.AWS_REGION }} \
+                                         --query 'taskArns[0]' --output text)
+        echo "Executing Alembic migration in container: medic-api-container"
+        aws ecs execute-command --cluster $CLUSTER \
+                                --task "$TASK_ARN" \
+                                --container medic-api-container \
+                                --region ${{ env.AWS_REGION }} \
+                                --interactive \
+                                --command "bash -lc 'alembic upgrade head && alembic current'"
+
     # 배포 알림
     - name: Deployment notification
       run: |

--- a/alembic/versions/001_add_hospital_seed_fields.py
+++ b/alembic/versions/001_add_hospital_seed_fields.py
@@ -1,0 +1,104 @@
+"""Add hospital fields from seed data
+
+Revision ID: 001_add_hospital_seed_fields
+Revises:
+Create Date: 2025-09-12 12:55:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "001_add_hospital_seed_fields"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 기존 hospitals 테이블에 시드 데이터 필드들만 추가
+
+    # 시드 데이터 추가 필드들
+    op.add_column("hospitals", sa.Column("opening_date", sa.Date(), nullable=True))
+    op.add_column("hospitals", sa.Column("total_doctors", sa.Integer(), nullable=True))
+    op.add_column("hospitals", sa.Column("dong_name", sa.String(), nullable=True))
+
+    # 주차 정보
+    op.add_column("hospitals", sa.Column("parking_slots", sa.Integer(), nullable=True))
+    op.add_column(
+        "hospitals", sa.Column("parking_fee_required", sa.String(), nullable=True)
+    )
+    op.add_column("hospitals", sa.Column("parking_notes", sa.Text(), nullable=True))
+
+    # 휴진 안내
+    op.add_column("hospitals", sa.Column("closed_sunday", sa.String(), nullable=True))
+    op.add_column("hospitals", sa.Column("closed_holiday", sa.String(), nullable=True))
+
+    # 응급실 운영
+    op.add_column(
+        "hospitals", sa.Column("emergency_day_available", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "hospitals", sa.Column("emergency_day_phone1", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "hospitals", sa.Column("emergency_day_phone2", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "hospitals", sa.Column("emergency_night_available", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "hospitals", sa.Column("emergency_night_phone1", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "hospitals", sa.Column("emergency_night_phone2", sa.String(), nullable=True)
+    )
+
+    # 점심시간 및 접수시간
+    op.add_column(
+        "hospitals", sa.Column("lunch_time_weekday", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "hospitals", sa.Column("lunch_time_saturday", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "hospitals", sa.Column("reception_time_weekday", sa.String(), nullable=True)
+    )
+    op.add_column(
+        "hospitals", sa.Column("reception_time_saturday", sa.String(), nullable=True)
+    )
+
+    # 진료시간 (요일별) - JSON 타입
+    op.add_column(
+        "hospitals",
+        sa.Column(
+            "treatment_hours", postgresql.JSON(astext_type=sa.Text()), nullable=True
+        ),
+    )
+
+
+def downgrade() -> None:
+    # hospitals 테이블에서 추가한 시드 데이터 필드들 제거
+    op.drop_column("hospitals", "treatment_hours")
+    op.drop_column("hospitals", "reception_time_saturday")
+    op.drop_column("hospitals", "reception_time_weekday")
+    op.drop_column("hospitals", "lunch_time_saturday")
+    op.drop_column("hospitals", "lunch_time_weekday")
+    op.drop_column("hospitals", "emergency_night_phone2")
+    op.drop_column("hospitals", "emergency_night_phone1")
+    op.drop_column("hospitals", "emergency_night_available")
+    op.drop_column("hospitals", "emergency_day_phone2")
+    op.drop_column("hospitals", "emergency_day_phone1")
+    op.drop_column("hospitals", "emergency_day_available")
+    op.drop_column("hospitals", "closed_holiday")
+    op.drop_column("hospitals", "closed_sunday")
+    op.drop_column("hospitals", "parking_notes")
+    op.drop_column("hospitals", "parking_fee_required")
+    op.drop_column("hospitals", "parking_slots")
+    op.drop_column("hospitals", "dong_name")
+    op.drop_column("hospitals", "total_doctors")
+    op.drop_column("hospitals", "opening_date")

--- a/alembic/versions/002_add_specialist_count_to_hospital_departments.py
+++ b/alembic/versions/002_add_specialist_count_to_hospital_departments.py
@@ -1,0 +1,30 @@
+"""Add specialist_count to hospital_departments
+
+Revision ID: 002_add_specialist_count
+Revises: 001_add_hospital_seed_fields
+Create Date: 2025-09-13 02:05:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "002_add_specialist_count"
+down_revision: Union[str, None] = "001_add_hospital_seed_fields"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "hospital_departments",
+        sa.Column("specialist_count", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("hospital_departments", "specialist_count")
+

--- a/alembic/versions/003_create_hospital_types.py
+++ b/alembic/versions/003_create_hospital_types.py
@@ -1,0 +1,34 @@
+"""create hospital_types
+
+Revision ID: 003_create_hospital_types
+Revises: 002_add_specialist_count
+Create Date: 2025-09-13 02:25:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "003_create_hospital_types"
+down_revision: Union[str, None] = "002_add_specialist_count"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "hospital_types",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("code", sa.String(), nullable=False, unique=True),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("hospital_types")
+

--- a/alembic/versions/004_create_disease_equipment_categories.py
+++ b/alembic/versions/004_create_disease_equipment_categories.py
@@ -1,0 +1,48 @@
+"""create disease_equipment_categories
+
+Revision ID: 004_create_disease_equipment_categories
+Revises: 003_create_hospital_types
+Create Date: 2025-09-13 03:05:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "004_disease_equipment"
+down_revision: Union[str, None] = "003_create_hospital_types"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "disease_equipment_categories",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("disease_id", sa.Integer(), sa.ForeignKey("diseases.id", ondelete="CASCADE"), nullable=False),
+        sa.Column(
+            "equipment_category_id",
+            sa.Integer(),
+            sa.ForeignKey("medical_equipment_categories.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("disease_name", sa.String(), nullable=False),
+        sa.Column("equipment_category_name", sa.String(), nullable=False),
+        sa.Column("equipment_category_code", sa.String(), nullable=False),
+        sa.Column("source", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_disease_equipment_category",
+        "disease_equipment_categories",
+        ["disease_id", "equipment_category_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_disease_equipment_category", "disease_equipment_categories", type_="unique")
+    op.drop_table("disease_equipment_categories")

--- a/app/schemas/medical.py
+++ b/app/schemas/medical.py
@@ -113,9 +113,23 @@ class HospitalResponse(BaseModel):
     id: int
     name: str
     address: str
+    latitude: float
+    longitude: float
     hospital_type_name: Optional[str] = None
     phone: Optional[str] = None
     created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class HospitalGeoResponse(BaseModel):
+    """병원 위치 요약 응답"""
+
+    id: int
+    name: str
+    latitude: float
+    longitude: float
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
- Add GH Actions step to run Alembic migrations via ECS execute-command on API service after service update
- Enable execute-command idempotently
- Track historical Alembic versions (001-004) previously ignored by .gitignore

Notes:
- Requires ECS service execute-command to be enabled and SSM permissions on task role
- If exec is unavailable, consider a one-off migration task or migration job runner.