### PR TITLE
API: hospitals include lat/lon + new geo listing endpoint

### DIFF
--- a/app/schemas/medical.py
+++ b/app/schemas/medical.py
@@ -113,9 +113,23 @@ class HospitalResponse(BaseModel):
     id: int
     name: str
     address: str
+    latitude: float
+    longitude: float
     hospital_type_name: Optional[str] = None
     phone: Optional[str] = None
     created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class HospitalGeoResponse(BaseModel):
+    """병원 위치 요약 응답"""
+
+    id: int
+    name: str
+    latitude: float
+    longitude: float
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
- Add latitude/longitude to HospitalResponse so /api/medical/hospitals includes coordinates
- New endpoint GET /api/medical/hospitals/geo returns [{id,name,latitude,longitude}] with optional filters:
  - ?hospital_id=ID (exact)
  - ?name=키워드 (ILIKE)

Backward compatible: HospitalDetailResponse unchanged; existing clients get extra fields for list response.