### PR TITLE
Local dev: fix alembic id; docker override profile; migrate-local script

### DIFF
--- a/alembic/versions/004_create_disease_equipment_categories.py
+++ b/alembic/versions/004_create_disease_equipment_categories.py
@@ -11,7 +11,7 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "004_disease_equipment"
+revision: str = "004_create_disease_equipment_categories"
 down_revision: Union[str, None] = "003_create_hospital_types"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/alembic/versions/004_create_disease_equipment_categories.py
+++ b/alembic/versions/004_create_disease_equipment_categories.py
@@ -11,7 +11,7 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "004_create_disease_equipment_categories"
+revision: str = "004_disease_equipment"
 down_revision: Union[str, None] = "003_create_hospital_types"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/alembic/versions/005_add_last_recommendation_pivot_to_chat_rooms.py
+++ b/alembic/versions/005_add_last_recommendation_pivot_to_chat_rooms.py
@@ -2,7 +2,7 @@
 Add last_recommendation_message_id to chat_rooms for windowed context
 
 Revision ID: 005_add_chatroom_pivot
-Revises: 004_create_disease_equipment_categories
+Revises: 004_disease_equipment
 Create Date: 2025-09-13
 """
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '005_add_chatroom_pivot'
-down_revision = '004_create_disease_equipment_categories'
+down_revision = '004_disease_equipment'
 branch_labels = None
 depends_on = None
 
@@ -26,4 +26,3 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_column('chat_rooms', 'last_recommendation_message_id')
-

--- a/scripts/migrate-local.sh
+++ b/scripts/migrate-local.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[local-migrate] Bringing up containers (no mock override)"
+docker compose -f docker-compose.yml up -d --build
+
+echo "[local-migrate] Waiting for API"
+for i in $(seq 1 20); do
+  if docker compose -f docker-compose.yml exec -T api python -c 'print(1)' >/dev/null 2>&1; then
+    break
+  fi
+  echo "  waiting... ($i)"; sleep 2
+done
+
+echo "[local-migrate] Running Alembic upgrade on RDS"
+# PYTHONPATH is cleared to avoid shadowing site-packages alembic by /app/alembic package name
+docker compose -f docker-compose.yml exec -T api bash -lc 'PYTHONPATH= alembic upgrade head && PYTHONPATH= alembic current'
+
+echo "[local-migrate] Done"
+


### PR DESCRIPTION
- Fix alembic revision id mismatch in 004 (matches 005 down_revision)
- Put docker-compose.override.yml behind profile 'mock' so local default run doesn't fail
- Add scripts/migrate-local.sh to bring up compose and run Alembic against RDS with PYTHONPATH cleared

Usage:
- ./scripts/migrate-local.sh
