### PR TITLE
feat: API 구조 개선 및 임계치 기반 증상 분석 로직 구현

### DIFF
--- a/app/models/model_inference.py
+++ b/app/models/model_inference.py
@@ -17,11 +17,26 @@ class ModelInferenceResult(Base):
     __tablename__ = "model_inference_results"
 
     id = Column(Integer, primary_key=True)
+
+    # 사용자 및 채팅방 정보 (채팅 메시지와 연결되지 않은 경우)
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=True,  # 채팅 메시지와 연결된 경우에는 선택적
+    )
+    chat_room_id = Column(
+        Integer,
+        ForeignKey("chat_rooms.id", ondelete="CASCADE"),
+        nullable=True,  # 채팅 메시지와 연결된 경우에는 선택적
+    )
+
+    # 채팅 메시지 연결 (기존 방식과의 호환성)
     chat_message_id = Column(
         Integer,
         ForeignKey("chat_messages.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,  # 독립적인 추론 결과도 허용
     )
+
     input_text = Column(Text, nullable=False)
     processed_text = Column(Text, nullable=True)  # 형태소 분석된 텍스트
 
@@ -29,9 +44,10 @@ class ModelInferenceResult(Base):
     first_disease_id = Column(
         Integer,
         ForeignKey("diseases.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,  # 질병 매핑이 없는 경우도 허용
     )
     first_disease_score = Column(Float, nullable=False)
+    first_disease_label = Column(String, nullable=True)  # 질병명 저장
 
     # 2순위 예측
     second_disease_id = Column(
@@ -40,6 +56,7 @@ class ModelInferenceResult(Base):
         nullable=True,
     )
     second_disease_score = Column(Float, nullable=True)
+    second_disease_label = Column(String, nullable=True)
 
     # 3순위 예측
     third_disease_id = Column(
@@ -48,6 +65,7 @@ class ModelInferenceResult(Base):
         nullable=True,
     )
     third_disease_score = Column(Float, nullable=True)
+    third_disease_label = Column(String, nullable=True)
 
     inference_time = Column(Float, nullable=True)
 
@@ -59,6 +77,8 @@ class ModelInferenceResult(Base):
     deleted_at = Column(DateTime, nullable=True)
 
     # 관계 설정
+    user = relationship("User", back_populates="inference_results")
+    chat_room = relationship("ChatRoom", back_populates="inference_results")
     chat_message = relationship("ChatMessage", back_populates="inference_result")
     first_disease = relationship(
         "Disease", foreign_keys=[first_disease_id], back_populates="first_predictions"

--- a/app/schemas/medical.py
+++ b/app/schemas/medical.py
@@ -361,9 +361,10 @@ class HospitalRecommendationRequest(BaseModel):
 
     inference_result_id: int = Field(..., description="모델 추론 결과 ID")
     chat_room_id: int = Field(..., description="채팅방 ID")
-    user_id: str = Field(..., description="사용자 ID (UUID)")
     max_distance: Optional[float] = Field(5.0, description="최대 검색 거리 (km)")
-    limit: Optional[int] = Field(3, description="추천 병원 수")
+    limit: Optional[int] = Field(
+        None, description="추천 병원 수 (None일 경우 모든 병원 반환)"
+    )
 
 
 class RecommendedHospitalResponse(BaseModel):
@@ -406,36 +407,6 @@ class HospitalRecommendationResponse(BaseModel):
 
 
 # ===== 장비 관련 스키마 =====
-
-
-class HospitalRecommendationByDiseaseRequest(BaseModel):
-    """질병 ID 기반 병원 추천 요청
-
-    - 사용자 식별은 토큰 기반(current_user)으로 수행
-    - 웹소켓 로직과 동일한 처리를 위해 DB 저장 포함
-    """
-
-    disease_id: int = Field(..., description="질병 ID")
-    chat_room_id: int = Field(..., description="채팅방 ID")
-    max_distance: Optional[float] = Field(20.0, description="최대 검색 거리 (km)")
-    limit: Optional[int] = Field(3, description="추천 병원 수")
-
-
-class HospitalRecommendationByDiseaseResponse(BaseModel):
-    """질환명 기반 병원 추천(라이트) 응답"""
-
-    chat_room_id: int
-    user_id: str
-    user_nickname: str
-    user_location: str
-    final_disease: Dict[str, Any]
-    total_candidates: int
-    recommendations: List[RecommendedHospitalResponse]
-    search_criteria: Dict[str, Any]
-    required_equipment: Optional[List[str]] = None
-
-    class Config:
-        from_attributes = True
 
 
 class EquipmentCategoryBase(BaseModel):

--- a/app/services/chat_service.py
+++ b/app/services/chat_service.py
@@ -106,6 +106,21 @@ class ChatService:
         )
 
     @staticmethod
+    def get_recent_user_messages(
+        db: Session, room_id: int, limit: int = 5
+    ) -> List[ChatMessage]:
+        """최근 사용자 메시지들 조회 (시간순 정렬)"""
+        return (
+            db.query(ChatMessage)
+            .filter(
+                ChatMessage.chat_room_id == room_id, ChatMessage.message_type == "USER"
+            )
+            .order_by(ChatMessage.created_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+    @staticmethod
     def get_chat_messages(
         db: Session, room_id: int, limit: int = 50
     ) -> List[ChatMessage]:


### PR DESCRIPTION
## 주요 변경사항

### API 구조 개선
- 채팅 API 단순화: /api/chat/rooms/{room_id}/messages에서 ML 분석 로직 제거, 메시지 저장만 담당
- 역할 분리: 각 API가 명확한 역할을 가지도록 구조 개선

### ML API 채팅방 컨텍스트 추가
- /api/ml/analyze-symptom: 기존 채팅 메시지들과 합쳐서 분석
- 컨텍스트 유지: 최근 5개 사용자 메시지와 새 메시지를 결합하여 분석
- 점진적 개선: 더 많은 증상 정보가 있을수록 정확도 향상

### 임계치 기반 증상 분석 로직
- 임계치 기준: 0.8 (80%) 신뢰도 기준
- 임계치 이하: 증상 추가 요구 응답, DB 저장 안함
- 임계치 이상: 정상 분석 결과 + DB 저장 + 병원 추천 가능

### 병원 추천 API 개선
- DB 저장: 모든 병원 추천 결과가 HospitalRecommendation 테이블에 저장
- limit 처리: None일 경우 반경 내 모든 병원 반환
- JWT 인증: 사용자 ID를 토큰에서 자동 추출

### 스키마 변경
- HospitalRecommendationRequest: limit 기본값을 None으로 변경
- 유연성: 필요에 따라 모든 병원 또는 제한된 수만 반환 가능

## 프론트엔드 사용 플로우

1. 메시지 전송: POST /api/chat/rooms/123/messages
2. 증상 분석: POST /api/ml/analyze-symptom (기존 메시지와 합쳐서)
3. 병원 추천: POST /api/medical/recommend-hospitals (모든 병원)